### PR TITLE
Сужает Browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+> 0.5%, last 3 versions, Firefox ESR, not dead

--- a/package.json
+++ b/package.json
@@ -1,13 +1,8 @@
 {
   "name": "Liga-A-accelerator-template",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "description": "Стартовый шаблон сборки Лиги А",
-  "browserslist": [
-    "last 3 versions",
-    "IE 11",
-    "Firefox ESR"
-  ],
   "scripts": {
     "editorconfig": "editorconfig-cli",
     "stylelint": "stylelint \"source/sass/**/*.scss\" --syntax scss",


### PR DESCRIPTION
Microsoft уже давно отказалась от поддержки IE11, так что нет смысла тратить на него силы разработчиков.
А тем более **начинающих** разработчиков.

Сделал выборку похожую на рекомендованный `defaults` от разработчиков Browserslist, только вместо 2 последних версий оставил 3, как было раньше